### PR TITLE
Add option to read keys from alternate dirs

### DIFF
--- a/manifests/server/keys.pp
+++ b/manifests/server/keys.pp
@@ -1,15 +1,15 @@
-# Class: ssh::server::keys
+#
+# = Class: ssh::server::keys
 #
 # This module manages keys for ssh server,
 # and is only intended to use as ssh::server
 # helper class
 #
 class ssh::server::keys (
+  $sourcedir     = 'puppet:///private/ssh',
   $private_mode  = $::ssh::params::private_mode,
   $private_group = $::ssh::params::private_group,
 ) inherits ssh::params {
-
-  $keys_dir = $::ssh::server::keys_dir
 
   File {
     ensure  => file,
@@ -24,80 +24,52 @@ class ssh::server::keys (
   file { '/etc/ssh/ssh_host_dsa_key':
     group  => $private_group,
     mode   => $private_mode,
-    source => [
-      'puppet:///private/ssh/ssh_host_dsa_key',
-      'puppet:///modules/ssh/ssh_host_dsa_key',
-    ],
+    source => "${sourcedir}/ssh_host_dsa_key",
   }
   file { '/etc/ssh/ssh_host_dsa_key.pub':
-    source => [
-      'puppet:///private/ssh/ssh_host_dsa_key.pub',
-      'puppet:///modules/ssh/ssh_host_dsa_key.pub',
-    ],
+    source => "${sourcedir}/ssh_host_dsa_key.pub",
   }
 
   # RSA1 key
   file { '/etc/ssh/ssh_host_key':
     group  => $private_group,
     mode   => $private_mode,
-    source => [
-      'puppet:///private/ssh/ssh_host_key',
-      'puppet:///modules/ssh/ssh_host_key',
-    ],
+    source => "${sourcedir}/ssh_host_key",
   }
   file { '/etc/ssh/ssh_host_key.pub':
-    source => [
-      'puppet:///private/ssh/ssh_host_key.pub',
-      'puppet:///modules/ssh/ssh_host_key.pub',
-    ],
+    source => "${sourcedir}/ssh_host_key.pub",
   }
 
   # RSA key
   file { '/etc/ssh/ssh_host_rsa_key':
     group  => $private_group,
     mode   => $private_mode,
-    source => [
-      'puppet:///private/ssh/ssh_host_rsa_key',
-      'puppet:///modules/ssh/ssh_host_rsa_key',
-    ],
+    source => "${sourcedir}/ssh_host_rsa_key",
   }
   file { '/etc/ssh/ssh_host_rsa_key.pub':
-    source => [
-      'puppet:///private/ssh/ssh_host_rsa_key.pub',
-      'puppet:///modules/ssh/ssh_host_rsa_key.pub',
-    ],
+    source => "${sourcedir}/ssh_host_rsa_key.pub",
   }
 
   # ECDSA key
   file { '/etc/ssh/ssh_host_ecdsa_key':
     group  => $private_group,
     mode   => $private_mode,
-    source => [
-      'puppet:///private/ssh/ssh_host_ecdsa_key',
-      'puppet:///modules/ssh/ssh_host_ecdsa_key',
-    ],
+    source => "${sourcedir}/ssh_host_ecdsa_key",
   }
   file { '/etc/ssh/ssh_host_ecdsa_key.pub':
-    source => [
-      'puppet:///private/ssh/ssh_host_ecdsa_key.pub',
-      'puppet:///modules/ssh/ssh_host_ecdsa_key.pub',
-    ],
+    source => "${sourcedir}/ssh_host_ecdsa_key.pub",
   }
 
-  # ED25519 key
-  file { '/etc/ssh/ssh_host_ed25519_key':
-    group  => $private_group,
-    mode   => $private_mode,
-    source => [
-      'puppet:///private/ssh/ssh_host_ed25519_key',
-      'puppet:///modules/ssh/ssh_host_ed25519_key',
-    ],
-  }
-  file { '/etc/ssh/ssh_host_ed25519_key.pub':
-    source => [
-      'puppet:///private/ssh/ssh_host_ed25519_key.pub',
-      'puppet:///modules/ssh/ssh_host_ed25519_key.pub',
-    ],
+  # ED25519 key: can be enabled if master is EL7
+  if ( 0 + $::facts['os']['release']['major'] > 6 ) {
+    file { '/etc/ssh/ssh_host_ed25519_key':
+      group  => $private_group,
+      mode   => $private_mode,
+      source => "${sourcedir}/ssh_host_ed25519_key",
+    }
+    file { '/etc/ssh/ssh_host_ed25519_key.pub':
+      source => "${sourcedir}/ssh_host_ed25519_key.pub",
+    }
   }
 
 }


### PR DESCRIPTION
I want to avoid a need to keep the SSH keys in additional puppetmaster share with hardcoded name `private`.

This PR enables user to set source dir where the SSH key are gonna be kept. It also avoids to copy the stronger SSH keys introduced in EL7 if the client is running EL6.